### PR TITLE
Use SSH SCP with private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_network"></a> [network](#input\_network) | n/a | <pre>list(object({<br>    bridge   = string<br>    vlan_tag = optional(number, -1)<br>    mac      = optional(string, null)<br>  }))</pre> | n/a | yes |
 | <a name="input_pubkey_path"></a> [pubkey\_path](#input\_pubkey\_path) | value | `string` | n/a | yes |
 | <a name="input_pve_host"></a> [pve\_host](#input\_pve\_host) | description | `string` | n/a | yes |
-| <a name="input_pve_password"></a> [pve\_password](#input\_pve\_password) | description | `string` | n/a | yes |
+| <a name="input_pve_private_key"></a> [pve\_private\_key](#input\_pve\_private\_key) | Key MUST be in authorized\_keys as command="scp -t /path/to/ci/snippets",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 <key> | `string` | n/a | yes |
 | <a name="input_pve_user"></a> [pve\_user](#input\_pve\_user) | description | `string` | n/a | yes |
 | <a name="input_qemu_os"></a> [qemu\_os](#input\_qemu\_os) | value | `string` | `"l26"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `list(string)` | n/a | yes |

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -32,14 +32,22 @@ resource "null_resource" "cloud_init_config_files" {
 
   provisioner "file" {
     source      = local_file.cloud_init_user_data_file.filename
-    destination = "/var/lib/${local.ci_file_storage}/${local.ci_file_relative_path_user}"
+    destination = "/${local.ci_file_user_filename}" # Non-standard path. Read note below
   }
 
+  # Connection REQUIRES the following line in ~/.ssh/authorized_keys:
+  # command="scp -t /path/to/ci/snippets",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 <key>
+  # which will prevent the key from shell access & restrict SCP destination.
+  # In /etc/ssh/sshd_config, the line:
+  # Subsystem sftp internal-sftp
+  # is commented out, to restrict sftp access (forces scp to use custom OpenSSL protocol).
+  # NOTE: this only works with OpenSSH version <9.0 (since in >=9.0, scp uses sftp as backend)
+  # TF `provisioner file` runs ssh + scp (remote), thus using `ForceCommand internal-stfp` does not work with TF.
   connection {
-    type     = "ssh"
-    host     = var.pve_host
-    user     = var.pve_user
-    password = var.pve_password
-    agent    = false
+    type        = "ssh"
+    host        = var.pve_host
+    user        = var.pve_user
+    private_key = var.pve_private_key
+    agent       = false
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -111,9 +111,9 @@ variable "pve_user" {
   sensitive   = true
 }
 
-variable "pve_password" {
+variable "pve_private_key" {
   type        = string
-  description = "description"
+  description = "Key MUST be in authorized_keys as command=\"scp -t /path/to/ci/snippets\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 <key>"
   sensitive   = true
 }
 


### PR DESCRIPTION
Connection REQUIRES the following line in `~/.ssh/authorized_keys`:
```
command="scp -t /path/to/ci/snippets",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 <key>
```
which will prevent the key from shell access & restrict SCP destination.

In `/etc/ssh/sshd_config`, the line:
`Subsystem sftp internal-sftp`
is commented out, to restrict sftp access (forces scp to use custom OpenSSL protocol).

NOTE: this only works with OpenSSH version <9.0 (since in >=9.0, scp uses sftp as backend)

TF `provisioner file` runs ssh + scp (remote), thus using `ForceCommand internal-stfp` does not work with TF.
